### PR TITLE
Added gzip calculation

### DIFF
--- a/StatusBarFileSize.py
+++ b/StatusBarFileSize.py
@@ -1,3 +1,6 @@
+import base64
+import gzip
+import io
 import os.path
 import sublime
 import sublime_plugin
@@ -73,8 +76,8 @@ ENCODING_MAP = {
 
 CONSTANT_OVERHEAD = {
     # Apparently ST doesn't add BOMs.
-    # "UTF-16 LE": 2,
-    # "UTF-16 BE": 2,
+    # "UTF-16 LE": b"\xFF\xFE",
+    # "UTF-16 BE": b"\xFE\xFF",
 }
 
 # Ditto for line endings. At least there's only three forms here.
@@ -99,23 +102,38 @@ def count_hex_digits(s):
     return sum(1 for x in s if x in "abcdefABCDEF0123456789")
 
 
+def parse_hexlike_str(s):
+    spaceless_s = ''.join(x for x in s if x in "abcdefABCDEF0123456789")
+    return base64.b16decode(spaceless_s.upper())
+
+
+def get_view_info(view):
+    line_endings = LINE_ENDINGS_MAP[view.line_endings()]
+    encoding = ENCODING_MAP[view.encoding()]
+    overhead = CONSTANT_OVERHEAD.get(view.encoding(), "")
+    return line_endings, encoding, overhead
+
+
+def iterate_view_blocks(view):
+    for start, end in ranges(0, view.size(), BLOCK_SIZE):
+        r = sublime.Region(start, end)
+        yield r
+
+
 def estimate_file_size(view):
     tag = view.change_count()
 
     try:
-        line_endings = LINE_ENDINGS_MAP[view.line_endings()]
-        encoding = ENCODING_MAP[view.encoding()]
-        overhead = CONSTANT_OVERHEAD.get(view.encoding(), 0)
+        line_endings, encoding, overhead = get_view_info(view)
     except KeyError:
         # Unknown encoding or line ending, so we fail.
         return None
 
-    size = overhead
-    for start, end in ranges(0, view.size(), BLOCK_SIZE):
+    size = len(overhead)
+    for r in iterate_view_blocks(view):
         if view.change_count() != tag:
             # Buffer was changed, we abort our mission.
             return None
-        r = sublime.Region(start, end)
         text = view.substr(r)
 
         if encoding == SPECIAL_HEXADECIMAL:
@@ -134,36 +152,85 @@ def estimate_file_size(view):
     return int(size)
 
 
+def calculate_gzip_size(view):
+    tag = view.change_count()
+
+    try:
+        line_endings, encoding, overhead = get_view_info(view)
+    except KeyError:
+        # Unknown encoding or line ending, so we fail.
+        return None
+
+    byte_content = io.BytesIO()
+    with gzip.GzipFile(fileobj=byte_content, mode="wb") as f:
+        f.write(overhead)
+        for r in iterate_view_blocks(view):
+            if view.change_count() != tag:
+                # Buffer was changed, we abort our mission.
+                return None
+            text = view.substr(r)
+
+            if encoding == SPECIAL_HEXADECIMAL:
+                # Special-case handling for the special-case Hexadecimal encoding.
+                # Strip out whitespace and convert it to bytes (e.g. "4849 5955" -> b"\x48\x49\x59\x55")
+                encoded_text = parse_hexlike_str(text)
+            else:
+                try:
+                    encoded_text = text.replace("\n", line_endings).encode(encoding)
+                except UnicodeError:
+                    # Encoding failed, we just fail here.
+                    return None
+            f.write(encoded_text)
+    return int(byte_content.tell())
+
+
 class StatusBarFileSize(sublime_plugin.EventListener):
     KEY_SIZE = "FileSize"
     SETTINGS = "StatusBarFileSize.sublime-settings"
     ESTIMATE_DEFAULT = True
+    CALCULATE_GZIP_DEFAULT = False
 
     @property
     def setting_estimate_file_size(self):
         settings = sublime.load_settings(self.SETTINGS)
         return settings.get("estimate_file_size", self.ESTIMATE_DEFAULT)
 
+    @property
+    def setting_calculate_gzip(self):
+        settings = sublime.load_settings(self.SETTINGS)
+        return settings.get("calculate_gzip", self.CALCULATE_GZIP_DEFAULT)
+
     def update_file_size(self, view):
         view.erase_status(self.KEY_SIZE)
 
+        size = None
+        gzip_size = None
         if not view.file_name() or view.is_dirty():
             if self.setting_estimate_file_size:
                 # Try to estimate the file size based on encoding and line
                 # endings.
                 size = estimate_file_size(view)
-                pattern = "~%s"
-            else:
-                size = None
+                pattern = "~{size}"
+                if self.setting_calculate_gzip:
+                    gzip_size = calculate_gzip_size(view)
+                    gzip_pattern = "~{size} ({gzip_size})"
         else:
             try:
                 size = os.path.getsize(view.file_name())
-                pattern = "%s"
+                pattern = "{size}"
+                if self.setting_calculate_gzip:
+                    # Faster to use content from buffer than reading on disk
+                    gzip_size = calculate_gzip_size(view)
+                    gzip_pattern = "{size} ({gzip_size})"
             except OSError:
-                size = None
+                pass
 
         if size is not None:
-            view.set_status(self.KEY_SIZE, pattern % file_size_str(size))
+            if gzip_size is not None:
+                status = gzip_pattern.format(size=file_size_str(size), gzip_size=file_size_str(gzip_size))
+            else:
+                status = pattern.format(size=file_size_str(size))
+            view.set_status(self.KEY_SIZE, status)
 
     on_post_save_async = update_file_size
     on_modified_async = update_file_size

--- a/StatusBarFileSize.sublime-settings
+++ b/StatusBarFileSize.sublime-settings
@@ -5,5 +5,8 @@
     // contents with the file encoding whenever the buffer is modified, it might
     // have a noticeable performance impact when working with large files on
     // slower machines.
-    "estimate_file_size": true
+    "estimate_file_size": true,
+    // As a web developer, you might be interested in the gzip size of a file
+    // use this to calculate said gzip size
+    "calculate_gzip": false
 }


### PR DESCRIPTION
A couple months ago I had a similar idea for this package except it was focused around getting both the normal size and gzip size for files.

https://gist.github.com/twolfson/4109692/revisions#diff-d680e8a854a7cbad6d490c445cba2ebaR171

Today I finally decided to write it. However, during my research I happily found this module =)

Unfortunately, it lacks gzip support (which is one of the key features I wanted). The reasoning is that as a web developer, I want to sometimes preview how big a script is going to be in production (where we use gzip).

This PR adds in gzip support to the repo via an opt-in flag. In this PR:
- Added `calculate_gzip` option
- Added gzip calculation/output via status bar

**Notes:**

I did some research on gzip to see if there was any more performant way of doing this estimation. Unfortunately, gzip is smart -- meaning we have to walk through it to get a decent measurement. Here is some nice reference material for those unfamiliar:
- Algorithm explanation http://www.gzip.org/algorithm.txt
- Visualization of gzip http://jvns.ca/blog/2013/10/24/day-16-gzip-plus-poetry-equals-awesome/
