### PR TITLE
Removed flickering and fixed compressed size calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ can be enabled in the settings.
 
 Use [Package Control][pkgctrl].
 
-This package only supports Sublime Text 3.
+This package only supports Sublime Text 3 and 4.
 
 [pkgctrl]: https://packagecontrol.io
 

--- a/StatusBarFileSize.py
+++ b/StatusBarFileSize.py
@@ -166,8 +166,9 @@ class StatusBarFileSize(sublime_plugin.EventListener):
         else:
             try:
                 size = os.path.getsize(view.file_name())
-                with open(view.file_name(), 'rb') as f:
-                    deflate_size = len(zlib.compress(f.read()))
+                if deflate:
+                    with open(view.file_name(), 'rb') as f:
+                        deflate_size = len(zlib.compress(f.read()))
             except OSError:
                 pass
 


### PR DESCRIPTION
## Changes
* Added Sublime Text 4 as supported (not only Sublime Text 3) to README
* Added check to not calculate compressed size when it is disabled and not displayed
* Removed status bar text flickering while quick-typing or erasing larger files (fixes #7). See below for comparison

https://user-images.githubusercontent.com/66842415/144714084-4702c016-3ff8-4339-b085-96b35178c0f0.mp4

https://user-images.githubusercontent.com/66842415/144714114-a19bf5ae-2064-4fdd-8421-a0d88619f5b9.mp4



