### PR TITLE
Do not use scientific notation when displaying file size

### DIFF
--- a/StatusBarFileSize.py
+++ b/StatusBarFileSize.py
@@ -23,7 +23,7 @@ def file_size_str(size, units='binary'):
         size_val /= divisor
         if size_val < divisor:
             break
-    return "{:.2} {}{}B".format(size_val, unit, binary_middle)
+    return "{:.2f} {}{}B".format(size_val, unit, binary_middle)
 
 
 # Far from a perfect system, but seems to be the only way to get a usable Python


### PR DESCRIPTION
`{:.2}` defaults to something similar to `{:.2g}`, and it uses scientific notation in some cases, so use `{:.2f}` instead in size formatting to prevent scientific notation

Before:
![file-size-fix-before](https://user-images.githubusercontent.com/66842415/167176319-fdfabae3-620c-4622-88c0-3b1217c74e30.png)

After:
![file-size-fix-after](https://user-images.githubusercontent.com/66842415/167176327-d8b4c729-9b34-4a83-9a7d-8654918e88f4.png)

